### PR TITLE
内蔵gitに対応

### DIFF
--- a/allow-empty-commit.bat
+++ b/allow-empty-commit.bat
@@ -1,1 +1,6 @@
-git commit --allow-empty -m "initial commit"
+where git
+if %errorlevel%==0 (
+    git commit --allow-empty -m "initial commit"
+) else (
+    %USERPROFILE%\AppData\Local\Atlassian\SourceTree\git_local\cmd\git.exe commit --allow-empty -m "initial commit"
+)


### PR DESCRIPTION
内蔵のgitを使っている場合に動かなかったので、
gitコマンドが見つからない（インストールされていない）場合は、内蔵のgitを使用するように修正しました。